### PR TITLE
build sqlite in action

### DIFF
--- a/.github/workflows/generate_sqlite.yml
+++ b/.github/workflows/generate_sqlite.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Publish SQLite
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: generate SQLite DB
+      run: ./ci.sh
+    - name: Cache libretrodb_tool
+      uses: actions/cache@v3
+      with:
+        path: >
+          libretrodb_tool
+          libretro-database
+        key: ${{ runner.os }}-${{ hashFiles('libretrodb_tool') }}
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: libretro-db.sqlite
+        asset_name: libretro-${{ github.ref }}.sqlite
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ ! -f  libretrodb_tool ];then
+  git clone https://github.com/libretro/RetroArch
+  cd RetroArch/libretro-db
+  make
+  cp ./libretrodb_tool ../..
+  cd ../..
+fi
+
+if [ ! -d libretro-database ];then
+  git clone https://github.com/libretro/libretro-database
+else
+  cd libretro-database
+  git pull
+  cd ..
+fi
+
+python3 libretro-sqlite-db.py


### PR DESCRIPTION
This will use github action to build an updated sqlite file on tag.

It caches libretrodb_tool and libretro-database (and uses git to update if needed) to make it run faster.

It will look like [this](https://github.com/notnullgames/libretro-sqlite-db/releases), next time you make a tag.

It might be ideal to get this setup upstream, at [libretro-database](https://github.com/libretro/libretro-database), so they just have an always-up-to-date sqlite release of their data.